### PR TITLE
Fix CommandBar browser destination initialization when SDK has already been initialized via snippet

### DIFF
--- a/packages/browser-destinations/src/destinations/commandbar/index.ts
+++ b/packages/browser-destinations/src/destinations/commandbar/index.ts
@@ -52,13 +52,11 @@ export const destination: BrowserDestinationDefinition<Settings, CommandBarClien
   ],
 
   initialize: async ({ settings }, deps) => {
-    const preloadedCommandBar = window.CommandBar
+    if (!window.CommandBar) {
+      initScript(settings.orgId)
+    }
 
-    initScript(settings.orgId)
-
-    await deps.resolveWhen(() => {
-      return window.CommandBar !== preloadedCommandBar
-    }, 100)
+    await deps.resolveWhen(() => Object.prototype.hasOwnProperty.call(window, 'CommandBar'), 100)
 
     return window.CommandBar
   },


### PR DESCRIPTION
## Change description
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->


During the private beta of the CommandBar browser destination, we noticed problems with the initialization of the destination.

The problem occurs when our client SDK has already been initialized elsewhere as the `resolveWhen` condition didn't properly account for that case. Our SDK implements a queue for calls that are made before it is fully initialized. Because of that, we can return the `window.CommandBar` SDK as soon as it is set.

## Testing


- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
